### PR TITLE
feat: Make liquidation arguments optional in score engine

### DIFF
--- a/shared_models/confidence_score_engine/main.py
+++ b/shared_models/confidence_score_engine/main.py
@@ -8,52 +8,37 @@ def generate_confidence_scores(
     cvd: pd.Series,
     open_interest: pd.Series,
     funding_rate: pd.Series,
-    long_liquidations: pd.Series,
-    short_liquidations: pd.Series,
+    long_liquidations: pd.Series = None,
+    short_liquidations: pd.Series = None,
     lookback_period: int = 20
 ) -> np.ndarray:
     """
     Orchestre le calcul complet des scores de confiance.
-
-    Cette fonction prend les séries temporelles brutes, calcule tous les facteurs,
-    les combine, puis les traite à travers le pipeline de prétraitement.
-
-    Args:
-        price (pd.Series): Série des prix.
-        cvd (pd.Series): Série du Cumulative Volume Delta.
-        open_interest (pd.Series): Série de l'Open Interest.
-        funding_rate (pd.Series): Série des taux de financement.
-        long_liquidations (pd.Series): Série des liquidations 'long'.
-        short_liquidations (pd.Series): Série des liquidations 'short'.
-        lookback_period (int, optional): Fenêtre de calcul pour les facteurs. Defaults to 20.
-
-    Returns:
-        np.ndarray: Un tableau NumPy contenant les caractéristiques finales,
-                    normalisées et dé-corrélées, prêtes pour un modèle ML.
+    Calcule uniquement les facteurs pour lesquels les données sont fournies.
     """
-    # ÉTAPE 1: Calculer chaque facteur brut en utilisant les fonctions importées.
-    divergence = calculate_divergence_score(price, cvd, lookback_period)
-    momentum = oi_weighted_funding_momentum(funding_rate, open_interest, lookback_period)
-    trapped_traders = trapped_trader_score(price, cvd, long_liquidations, short_liquidations, lookback_period)
+    # ÉTAPE 1: Initialiser un dictionnaire pour stocker les features calculées.
+    features = {}
 
-    # ÉTAPE 2: Combiner les facteurs en un seul DataFrame.
-    features_df = pd.DataFrame({
-        'divergence_score': divergence,
-        'oi_funding_momentum': momentum,
-        'trapped_trader_score': trapped_traders
-    })
+    # ÉTAPE 2: Calculer les facteurs de base (toujours présents).
+    features['divergence_score'] = calculate_divergence_score(price, cvd, lookback_period)
+    features['oi_funding_momentum'] = oi_weighted_funding_momentum(funding_rate, open_interest, lookback_period)
 
-    # ÉTAPE 3: Gérer les valeurs manquantes.
-    # Remplir les NaN qui peuvent résulter des fenêtres glissantes avant de traiter.
-    features_df.bfill(inplace=True) # Rétro-propagation
-    features_df.ffill(inplace=True) # Propagation avant
+    # ÉTAPE 3: Calculer les facteurs optionnels seulement si les données sont fournies.
+    if long_liquidations is not None and short_liquidations is not None:
+        features['trapped_trader_score'] = trapped_trader_score(
+            price, cvd, long_liquidations, short_liquidations, lookback_period
+        )
+
+    # ÉTAPE 4: Combiner les facteurs en un seul DataFrame.
+    features_df = pd.DataFrame(features)
+
+    # ... (Le reste de la fonction : gestion des NaN et application du pipeline) ...
+    features_df.fillna(method='bfill', inplace=True)
+    features_df.fillna(method='ffill', inplace=True)
 
     if features_df.empty or features_df.isnull().values.any():
-        # Si le DataFrame est toujours vide ou contient des NaN, retourner un tableau vide.
         return np.array([])
 
-    # ÉTAPE 4: Appliquer le pipeline de prétraitement.
-    # Le pipeline s'occupe de la normalisation (Quantile) et de la dé-corrélation (PCA).
     processed_features = preprocessing_pipeline.fit_transform(features_df)
 
     return processed_features


### PR DESCRIPTION
Refactor generate_confidence_scores to handle missing data.

The `generate_confidence_scores` function in the confidence score engine now supports optional `long_liquidations` and `short_liquidations` arguments.

This change increases the robustness of the function by allowing it to compute confidence scores even when liquidation data is not available. The function dynamically constructs the feature set based on the provided inputs, calculating the `trapped_trader_score` only when the necessary liquidation data is present.